### PR TITLE
Make apis be served from https://localhost/api/ ...

### DIFF
--- a/backend/players/views.py
+++ b/backend/players/views.py
@@ -72,7 +72,6 @@ def create_player(request):
 
 #     return JsonResponse({'error': 'Invalid request method'}, status=405)
 
-
 def oauth_redirect(request):
     # Get OAuth parameters from environment variables
     client_id = os.environ.get('OAUTH_CLIENT_ID')
@@ -88,7 +87,6 @@ def oauth_redirect(request):
     }
     auth_url = f"{base_url}?{urlencode(params)}"
     return HttpResponseRedirect(auth_url)
-
 
 def oauth_callback(request):
 
@@ -127,7 +125,6 @@ def fetch_42_user_data(access_token):
         return response.json()
     except requests.exceptions.RequestException as e:
         return {'error': f'Failed to fetch user data: {str(e)}'}
-
 
 def exchange_code_for_token(code):
  token_url = os.environ.get('OAUTH_TOKEN_URL')

--- a/backend/transc_api/settings.py
+++ b/backend/transc_api/settings.py
@@ -33,6 +33,8 @@ ALLOWED_HOSTS = [
     os.environ.get('DJANGO_HOST')
 ]
 
+CSRF_TRUSTED_ORIGINS = ['https://localhost']
+
 
 # Application definition
 

--- a/backend/transc_api/urls.py
+++ b/backend/transc_api/urls.py
@@ -19,5 +19,5 @@ from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('players/', include('players.urls'))
+    path('api/', include('players.urls'))
 ]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -33,31 +33,38 @@ http {
 		root /var/www/html/;
 		index index.html;
 		# try serving files in /var/www/html, if not found proxy request to django
+		# Serve static frontend first, fallback to Django backend
 		location / {
-			root /var/www/html/;
 			try_files $uri $uri/ @backend;
+			# try_files $uri /index.html ;
 		}
+
 		location @backend {
 			proxy_pass http://backend:8000;
+			proxy_http_version 1.1;
+			proxy_set_header Upgrade $http_upgrade;
+			proxy_set_header Connection 'upgrade';
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 			proxy_set_header X-Forwarded-Proto $scheme;
+			proxy_cache_bypass $http_upgrade;
+			proxy_read_timeout 90;
 		}
+
+		# # API endpoints, including Django admin
+		# location /api/ {
+		# 	proxy_pass http://backend:8000;  # Don't rewrite /api/admin path
+		# 	proxy_http_version 1.1;
+		# 	proxy_set_header Upgrade $http_upgrade;
+		# 	proxy_set_header Connection 'upgrade';
+		# 	proxy_set_header Host $host;
+		# 	proxy_set_header X-Real-IP $remote_addr;
+		# 	proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		# 	proxy_set_header X-Forwarded-Proto $scheme;
+		# 	proxy_cache_bypass $http_upgrade;
+		# 	proxy_read_timeout 90;
+		# }
 	}
-		server {
-		    listen 8443 ssl;
-		
-		    ssl_certificate /etc/nginx/ssl/cert.crt;
-		    ssl_certificate_key /etc/nginx/ssl/key.key;
-		
-		    # Proxy all requests on this port to Django
-		    location / {
-			proxy_pass http://backend:8000;
-		        proxy_set_header Host $host;
-		        proxy_set_header X-Real-IP $remote_addr;
-		        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		        proxy_set_header X-Forwarded-Proto $scheme;
-		    }
-		}
+
 }

--- a/frontend/src/login.html
+++ b/frontend/src/login.html
@@ -15,7 +15,7 @@
             
             // Open popup to your Django redirect view
             const popup = window.open(
-                'https://localhost:8443/players/oauth/redirect',
+                'https://localhost/api/oauth/redirect',
                 '42 Authorization',
                 `width=${width},height=${height},top=${top},left=${left}`
             );


### PR DESCRIPTION
..and admin from https://localhost/admin/

This way we will preserve same-origin as we will have the same protocol, host and port.

To make it work put this redirect link into you API app: `OAUTH_REDIRECT=https://localhost/api/oauth/callback/`
Trailing slash is important from my experiments :)