### PR TITLE
Update backend to user number type for consistency, Add query params, Update get current tournament 

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,12 +276,12 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/tournaments/`
 
-- **Description**: Create a tournament with 2 blank matches. These 2 first matches will have the players assigned in the order from `userIds`. The first match will have two first players with user ids from `userIds`, The second match will have players with the next ids from `userIds`. For the AI Player, id of "1" should be added to `userIds`. Tournament can only be created for 4 user ids. All users in ids array must be logged in.
+- **Description**: Create a tournament with 2 blank matches. These 2 first matches will have the players assigned in the order from `userIds`. The first match will have two first players with user ids from `userIds`, The second match will have players with the next ids from `userIds`. For the AI Player, id of `1` should be added to `userIds`. Tournament can only be created for 4 user ids. All users in ids array must be logged in.
 
 - **Request Body**:
 
   - `name` (string, required)
-  - `userIds` (string array, required)
+  - `userIds` (array of numbers, required)
 
 - **Example Response**:
 
@@ -829,13 +829,13 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/tournaments/{id}/matches/`
 
-- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score`: "11:4", `duration`: "3000". `duration` is passed in seconds as a string. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score: "11:4"`, `duration: 3000`. `duration` is passed in seconds as a string. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 
-  - `userIds` (string array, required)
+  - `userIds` (array of numbers, required)
   - `score` (string, optional)
-  - `duration` (string, optional)
+  - `duration` (number, optional)
 
 - **Example Response**:
 
@@ -852,13 +852,13 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/matches/`
 
-- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score`: "11:4", `duration`: "3000". `duration` is passed in seconds as a string. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score: "11:4"`, `duration: 3000`. `duration` is passed in seconds as a string. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 
-  - `userIds` (string array, required)
+  - `userIds` (array of numbers, required)
   - `score` (string, optional)
-  - `duration` (string, optional)
+  - `duration` (number, optional)
 
 - **Example Response**:
 
@@ -875,7 +875,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `PATCH /api/matches/{id}/`
 
-- **Description**: Update the match. Example of `score`: "11:4", `duration`: "3000". If the id would be found as the finals match in the tournament and the score is changed, winner of the tournament will be update accordingly. Users participating in the match must be logged in.
+- **Description**: Update the match. Example of `score: "11:4"`, `duration: 3000`. If the id would be found as the finals match in the tournament and the score is changed, winner of the tournament will be update accordingly. Users participating in the match must be logged in.
 
 - **URL Parameters**:
 
@@ -884,7 +884,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 - **Request Body**:
 
   - `score` (string, optional)
-  - `duration` (string, optional)
+  - `duration` (number, optional)
 
 - **Example Response**:
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,49 @@ When we refer to `id`, it is always id of the built-in Django User model.
 }
 ```
 
+#### Get Current Players (Users from the Sessions)
+
+- **Endpoint**: `GET /api/players/current/`
+
+- **Description**: Fetch the details of the logged in players. Returned ids are user ids.
+
+- **Example Response**:
+```
+{
+	"ok": true,
+	"message": "Players successfully listed!",
+	"data": {
+		"players": [
+			{
+				"id": 5,
+				"username": "paul",
+				"displayName": "Paul",
+				"avatarUrl": "/media/avatars/fallback.png",
+				"status": "Offline",
+				"createdAt": "2024-11-24T18:37:06.543396+00:00"
+			},
+			{
+				"id": 3,
+				"username": "tony",
+				"displayName": null,
+				"avatarUrl": "/media/avatars/fallback.png",
+				"status": "Offline",
+				"createdAt": "2024-11-24T18:37:02.210328+00:00"
+			},
+			{
+				"id": 4,
+				"username": "mary",
+				"displayName": "Mary",
+				"avatarUrl": "/media/avatars/fallback.png",
+				"status": "Offline",
+				"createdAt": "2024-11-24T18:37:04.732933+00:00"
+			}
+		]
+	},
+	"statusCode": 200
+}
+```
+
 #### Create a New User
 
 - **Endpoint**: `POST /api/players/`

--- a/README.md
+++ b/README.md
@@ -624,7 +624,9 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Query Parameters**:
 
-	- `last` **(optional)**: Specifies the number of matches to return. Must be a positive integer. If not provided, defaults to 10. Example: `GET /api/tournaments/?last=10`.
+	- `last` **(optional)**: Specifies the number of matches to return. Must be a positive integer. If not provided, defaults to 10. Example: `GET /api/matches/?last=10`.
+
+	- `finished` **(optional)**: Specifies to include only finished matches or not finished too. `?finished=false` mean that unfinished matches will be included. If not provided, defaults to true. Example: `GET /api/matches/?finished=false`.
 
 - **Example Response**:
 
@@ -837,12 +839,12 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/tournaments/{id}/matches/`
 
-- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score: "11:4"`, `duration: 3000`. `duration` is passed in seconds as a string. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a string. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 
   - `userIds` (array of numbers, required)
-  - `score` (string, optional)
+  - `score` (array of numbers, optional)
   - `duration` (number, optional)
 
 - **Example Response**:
@@ -860,12 +862,12 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/matches/`
 
-- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score: "11:4"`, `duration: 3000`. `duration` is passed in seconds as a string. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a string. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 
   - `userIds` (array of numbers, required)
-  - `score` (string, optional)
+  - `score` (array of numbers, optional)
   - `duration` (number, optional)
 
 - **Example Response**:
@@ -883,7 +885,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `PATCH /api/matches/{id}/`
 
-- **Description**: Update the match. Example of `score: "11:4"`, `duration: 3000`. If the id would be found as the finals match in the tournament and the score is changed, winner of the tournament will be update accordingly. Users participating in the match must be logged in.
+- **Description**: Update the match. Example of `score: [11, 4]`, `duration: 3000`. If the id would be found as the finals match in the tournament and the score is changed, winner of the tournament will be update accordingly. Users participating in the match must be logged in.
 
 - **URL Parameters**:
 
@@ -891,7 +893,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Request Body**:
 
-  - `score` (string, optional)
+  - `score` (array of numbers, optional)
   - `duration` (number, optional)
 
 - **Example Response**:

--- a/README.md
+++ b/README.md
@@ -349,11 +349,15 @@ Several users can be logged in at the same time. Each session is stored in cooki
 }
 ```
 
-#### Get 5 Last Tournaments
+#### Get Last Tournaments
 
 - **Endpoint**: `GET /api/tournaments/`
 
-- **Description**: Respond with array of 5 last tournaments which have `id`, `name`, `winner` object (which represents a tournament winner with its tournament `id`, `username`, `displayName`, `avatarUrl`, `status`), `createdAt`, `matches` array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+- **Description**: Responds with array of 5 last tournaments by default which have `id`, `name`, `winner` object (which represents a tournament winner with its tournament `id`, `username`, `displayName`, `avatarUrl`, `status`), `createdAt`, `matches` array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+
+- **Query Parameters**:
+
+	- `last` **(optional)**: Specifies the number of tournaments to return. Must be a positive integer. If not provided, defaults to 5. Example: `GET /api/tournaments/?last=10`.
 
 - **Example Response**:
 
@@ -612,11 +616,15 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 ### Matches Management
 
-#### Get 20 Last Matches
+#### Get Last Matches
 
 - **Endpoint**: `GET /api/matches/`
 
-- **Description**: Responds with array of 20 last `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+- **Description**: Responds with array of 10 last `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+
+- **Query Parameters**:
+
+	- `last` **(optional)**: Specifies the number of matches to return. Must be a positive integer. If not provided, defaults to 10. Example: `GET /api/tournaments/?last=10`.
 
 - **Example Response**:
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,62 @@ Several users can be logged in at the same time. Each session is stored in cooki
 {
 	"ok": true,
 	"message": "Tournament successfully created!",
-	"data": { "id": 3, "name": "New tournament" },
+	"data": {
+		"id": 3,
+		"name": "New tournament",
+		"winner": null,
+		"createdAt": "2024-11-25T16:22:42.311855+00:00",
+		"matches": [
+			{
+				"id": 10,
+				"players": [
+					{
+						"id": 1,
+						"username": "ai_player",
+						"displayName": "AI Player",
+						"avatarUrl": "/media/avatars/fallback.png",
+						"status": "Offline",
+						"createdAt": "2024-11-24T18:36:52.426637+00:00"
+					},
+					{
+						"id": 3,
+						"username": "tony",
+						"displayName": null,
+						"avatarUrl": "/media/avatars/fallback.png",
+						"status": "Offline",
+						"createdAt": "2024-11-24T18:37:02.210328+00:00"
+					}
+				],
+				"score": null,
+				"duration": null,
+				"createdAt": "2024-11-25T16:22:42.332828+00:00"
+			},
+			{
+				"id": 11,
+				"players": [
+					{
+						"id": 4,
+						"username": "mary",
+						"displayName": "Mary",
+						"avatarUrl": "/media/avatars/fallback.png",
+						"status": "Offline",
+						"createdAt": "2024-11-24T18:37:04.732933+00:00"
+					},
+					{
+						"id": 5,
+						"username": "paul",
+						"displayName": "Paul",
+						"avatarUrl": "/media/avatars/fallback.png",
+						"status": "Offline",
+						"createdAt": "2024-11-24T18:37:06.543396+00:00"
+					}
+				],
+				"score": null,
+				"duration": null,
+				"createdAt": "2024-11-25T16:22:42.338462+00:00"
+			}
+		]
+	},
 	"statusCode": 201
 }
 ```

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `GET /api/tournaments/`
 
-- **Description**: Responds with array of 5 last tournaments by default which have `id`, `name`, `winner` object (which represents a tournament winner with its tournament `id`, `username`, `displayName`, `avatarUrl`, `status`), `createdAt`, `matches` array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+- **Description**: Responds with array of 5 last tournaments by default which have `id`, `name`, `winner` object (which represents a tournament winner with its tournament `id`, `username`, `displayName`, `avatarUrl`, `status`), `createdAt`, `matches` array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). `winner`, `duration`, `score` will be `null` if not updated later with update final match or update match by id. No authentication required.
 
 - **Query Parameters**:
 
@@ -400,7 +400,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 								"createdAt": "2024-10-17T16:33:38.597270+00:00"
 							}
 						],
-						"score": "2:11",
+						"score": [2, 11],
 						"duration": 6541,
 						"createdAt": "2024-11-24T02:00:33.653346+00:00"
 					},
@@ -424,7 +424,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 								"createdAt": "2024-10-17T16:33:38.597270+00:00"
 							}
 						],
-						"score": "7:11",
+						"score": [7, 11],
 						"duration": 12003,
 						"createdAt": "2024-11-24T02:00:13.770529+00:00"
 					},
@@ -448,7 +448,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 								"createdAt": "2024-10-17T16:33:38.597270+00:00"
 							}
 						],
-						"score": "11:0",
+						"score": [11, 0],
 						"duration": 5000,
 						"createdAt": "2024-11-24T02:00:13.774048+00:00"
 					}
@@ -602,7 +602,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 							"createdAt": "2024-10-17T16:33:38.597270+00:00"
 						}
 					],
-					"score": "2:11",
+					"score": [2, 11],
 					"duration": null,
 					"createdAt": "2024-11-24T01:36:24.249875+00:00"
 				}
@@ -620,7 +620,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `GET /api/matches/`
 
-- **Description**: Responds with array of 10 last `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). No authentication required.
+- **Description**: By default, responds with array of 10 last `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). `score`, `duration` are initially `null` if not set. No authentication required.
 
 - **Query Parameters**:
 
@@ -656,7 +656,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-10-17T16:33:38.597270+00:00"
 					}
 				],
-				"score": "2:11",
+				"score": [2, 11],
 				"duration": null,
 				"createdAt": "2024-11-24T02:00:33.653346+00:00"
 			},
@@ -680,7 +680,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-10-17T16:33:38.597270+00:00"
 					}
 				],
-				"score": "11:0",
+				"score": [11, 0],
 				"duration": 5000,
 				"createdAt": "2024-11-24T02:00:13.774048+00:00"
 			},
@@ -704,7 +704,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-10-17T16:33:38.597270+00:00"
 					}
 				],
-				"score": "7:11",
+				"score": [7, 11],
 				"duration": null,
 				"createdAt": "2024-11-24T02:00:13.770529+00:00"
 			}
@@ -753,7 +753,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-11-24T01:36:14.914430+00:00"
 					}
 				],
-				"score": "2:11",
+				"score": [2, 11],
 				"duration": null,
 				"createdAt": "2024-11-24T02:00:33.653346+00:00"
 			},
@@ -777,7 +777,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-11-24T01:36:08.718477+00:00"
 					}
 				],
-				"score": "7:11",
+				"score": [7, 11],
 				"duration": null,
 				"createdAt": "2024-11-24T02:00:13.770529+00:00"
 			},
@@ -825,7 +825,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 						"createdAt": "2024-11-24T01:36:08.718477+00:00"
 					}
 				],
-				"score": "2:11",
+				"score": [2, 11],
 				"duration": null,
 				"createdAt": "2024-11-24T01:36:24.249875+00:00"
 			}
@@ -839,7 +839,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/tournaments/{id}/matches/`
 
-- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a string. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a final match on the tournament with `id`. A final match can be created only for 2 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a number. The First and second matches for tournaments are always created with the tournament creation. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 
@@ -862,7 +862,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `POST /api/matches/`
 
-- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a string. For all other users, logged in session is required. AI Player does not need a session.
+- **Description**: Create a new match. A match can be created only for 2 or 4 players. If the AI Player is in the match, the id of `ai_user` must be passed in `userIds` array. For 2 x 2 match, players with first two ids will be in the team 1 and players with the last 2 ids in array will be in the team 2. Example of `score: [11, 4]`, `duration: 3000`. `duration` is passed in seconds as a number. For all other users, logged in session is required. AI Player does not need a session.
 
 - **Request Body**:
 

--- a/backend/api/constants.py
+++ b/backend/api/constants.py
@@ -34,4 +34,4 @@ PLAYER_KEYS = ["player1", "player2", "player3", "player4"]
 WINNER_LOSER_KEYS = ["winner1", "winner2", "loser1", "loser2"]
 
 # AI Player User ID
-AI_ID = "1"
+AI_ID = 1

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path("csrf/", views.get_csrf_token, name="csrf"),
     path("players/", views.manage_players, name="manage_players"),
+    path("players/current/", views.get_current_players, name="get_current_players"),
     path("players/<int:id>/", views.manage_player, name="manage_player"),
     path('players/<int:id>/avatar/', views.upload_avatar, name='upload_avatar'),
     path('players/<int:id>/stats/', views.get_player_stats, name='get_player_stats'),

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -445,9 +445,10 @@ def manage_tournaments(request):
 
 # Get last 5 tournaments
 def get_tournaments(request):
+    last = int(request.GET.get('last') or 5)
     tournaments = (
         Tournament.objects.all()
-        .order_by("-id")[:5]
+        .order_by("-id")[:last]
         .select_related("winner")  # Fetch the winner Player object with the Tournament
         .prefetch_related(
             "participants__player",  # Prefetch Player objects from TournamentParticipant
@@ -698,7 +699,7 @@ def manage_tournament_match(request, id=None):
 def manage_matches(request):
     try:
         if request.method == "GET":
-            matches = get_matches()
+            matches = get_matches(request)
             return JsonResponse(
                 {
                     "ok": True,
@@ -723,8 +724,9 @@ def manage_matches(request):
     return JsonResponse({"ok": False, "error": "Invalid request method"}, status=405)
 
 
-def get_matches():
-    matches = Match.objects.all().order_by("-id")[:20]
+def get_matches(request):
+    last = int(request.GET.get('last') or 20)
+    matches = Match.objects.exclude(score__isnull=True).order_by("-id")[:last]
     return [form_match_json(match) for match in matches]
 
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -720,10 +720,13 @@ def manage_matches(request):
 
 
 def get_matches(request):
-    finished = request.GET.get('finished', 'true')
+    finished = request.GET.get('finished', "true")
     finished = finished.lower() == 'true'
     last = int(request.GET.get('last') or 20)
-    matches = Match.objects.exclude(score__isnull=finished).order_by("-id")[:last]
+    if finished:
+        matches = Match.objects.exclude(score__isnull=True).order_by("-id")[:last]
+    else:
+        matches = Match.objects.all().order_by("-id")[:last]
     return [form_match_json(match) for match in matches]
 
 
@@ -805,7 +808,7 @@ def check_sessions(request, ids):
 def check_score_format(score):
     # pattern = r"^\d+:\d+$"
     # if re.match(pattern, score):
-    if (len(score) == 2) and (score[0].isdigit() and score[1].isdigit()):
+    if isinstance(score, list) and len(score) == 2 and all(isinstance(part, int) for part in score):
         return True
     return False
 
@@ -836,7 +839,8 @@ def create_match(request, id=None):
     if score:
         if not check_score_format(score):
             raise BadRequest("Invalid score format. Example format: [11, 2]")
-        match.score = ":".join(score)
+        match.score = ":".join([str(num) for num in score])
+        print("match score: ", match.score)
         is_winners_first = True if score[0] > score[1] else False
         offset = 0 if is_winners_first else 2
         MODULO_DIV = 4
@@ -957,7 +961,7 @@ def update_match(request, id):
         is_winners_first = True if score[0] > score[1] else False
         offset = 0 if is_winners_first else 2
         MODULO_DIV = 4
-        match.score = ":".join(score)
+        match.score = ":".join([str(num) for num in score])
         for index, user_id in enumerate(user_ids):
             # Set winner1, winner2, loser1, loser2 (leaving winner2 and loser2 empty if 2 players)
             match.__setattr__(

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -663,7 +663,7 @@ def create_tournament(request):
         {
             "ok": True,
             "message": "Tournament successfully created!",
-            "data": {"id": tournament.id, "name": tournament.name},
+            "data": form_tournament_json(tournament),
             "statusCode": 201,
         },
         status=201,

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -544,7 +544,7 @@ def get_tournament(request, id):
 
 def find_ids_from_sessions(request):
     found_session_ids = [
-        int(decrypt_session_value(value)["id"])
+        decrypt_session_value(value)["id"]
         for key, value in request.COOKIES.items()
         if key.startswith("session_")
     ]
@@ -770,7 +770,7 @@ def get_player_matches(request, id):
 # Still the AI_ID should be provided in ids argument
 def check_sessions(request, ids):
     # Filter out None values
-    ids = [str(id) for id in ids if id is not None]
+    ids = [id for id in ids if id is not None]
 
     # print("ids")
     # for id in ids:
@@ -844,7 +844,7 @@ def create_match(request, id=None):
 
     duration_seconds = data.get("duration")
     if duration_seconds:
-        match.duration = timedelta(seconds=int(duration_seconds))
+        match.duration = timedelta(seconds=duration_seconds)
     tournament_id = id
     tournament = None
     if tournament_id:
@@ -864,8 +864,8 @@ def create_match(request, id=None):
             # print("tournament_match.player2.user.id")
             # print(tournament_match.player2.user.id)
             if not (
-                str(tournament_match.player1.user.id) in user_ids
-                or str(tournament_match.player2.user.id) in user_ids
+                tournament_match.player1.user.id in user_ids
+                or tournament_match.player2.user.id in user_ids
             ):
                 raise BadRequest("Players from semifinals must be in finals")
         match.tournament = Tournament.objects.get(id=tournament_id)
@@ -947,7 +947,7 @@ def update_match(request, id):
 
     duration_seconds = data.get("duration")
     if duration_seconds:
-        match.duration = timedelta(seconds=int(duration_seconds))
+        match.duration = timedelta(seconds=duration_seconds)
 
     score = data.get("score")
     step = 2 if user_ids_count == 2 else 1

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -78,6 +78,26 @@ def check_status(player):
     return "Online"
 
 
+def get_current_players(request):
+    try:
+        found_session_ids = find_ids_from_sessions(request)
+        players = players = Player.objects.filter(user__id__in=found_session_ids)
+        players_data = [form_player_json(player) for player in players]
+        return JsonResponse(
+            {
+                "ok": True,
+                "message": "Current players successfully listed!",
+                "data": {"players": players_data},
+                "statusCode": 200,
+            },
+            status=200,
+        )
+    except Exception as e:
+        return JsonResponse(
+            {"ok": False, "error": str(e), "statusCode": 500}, status=500
+        )
+
+
 @session_authenticated_logged_in
 def get_players(request):
     players = Player.objects.all()
@@ -522,15 +542,20 @@ def get_tournament(request, id):
     )
 
 
+def find_ids_from_sessions(request):
+    found_session_ids = [
+        int(decrypt_session_value(value)["id"])
+        for key, value in request.COOKIES.items()
+        if key.startswith("session_")
+    ]
+    return found_session_ids
+
+
 @csrf_exempt
 def get_current_sessions_tournament(request):
     try:
         if request.method == "GET":
-            found_session_ids = [
-                int(decrypt_session_value(value)["id"])
-                for key, value in request.COOKIES.items()
-                if key.startswith("session_")
-            ]
+            found_session_ids = find_ids_from_sessions(request)
             if len(found_session_ids) == 3:
                 found_session_ids.append(1)
             if len(found_session_ids) != 4:
@@ -644,8 +669,9 @@ def create_tournament(request):
         status=201,
     )
 
+
 @csrf_exempt
-def manage_tournament_match(request, id = None):
+def manage_tournament_match(request, id=None):
     try:
         if request.method == "POST":
             return create_match(request, id)
@@ -784,7 +810,7 @@ def check_score_format(score):
     return False
 
 
-def create_match(request, id = None):
+def create_match(request, id=None):
     if not request.body:
         raise BadRequest("No data provided")
     data = json.loads(request.body)

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -569,8 +569,6 @@ def get_current_sessions_tournament(request):
                     status=400,
                 )
             players = Player.objects.filter(user__id__in=found_session_ids)
-            # print("players")
-            # print(players)
             tournaments = (
                 Tournament.objects.annotate(
                     player_count=Count(
@@ -582,8 +580,6 @@ def get_current_sessions_tournament(request):
                 )
                 # .distinct()  # Avoid duplicates
             )
-            # print("tournaments")
-            # print(tournaments)
 
             if tournaments.exists():
                 # Return the first matching tournament (or adjust logic for multiple)
@@ -648,9 +644,8 @@ def create_tournament(request):
                 {"ok": False, "error": "Player ID is required", "statusCode": 400},
                 status=400,
             )
-        # print("user_id", user_id)
+
         player = get_player_by_user_id(user_id)
-        # print("player", player)
         TournamentParticipant.objects.create(
             tournament=tournament, player=player, order=index
         )
@@ -841,7 +836,7 @@ def create_match(request, id=None):
     if score:
         if not check_score_format(score):
             raise BadRequest("Invalid score format. Example format: [11, 2]")
-        match.score = score.join(":")
+        match.score = ":".join(score)
         is_winners_first = True if score[0] > score[1] else False
         offset = 0 if is_winners_first else 2
         MODULO_DIV = 4
@@ -962,7 +957,7 @@ def update_match(request, id):
         is_winners_first = True if score[0] > score[1] else False
         offset = 0 if is_winners_first else 2
         MODULO_DIV = 4
-        match.score = score.join(":")
+        match.score = ":".join(score)
         for index, user_id in enumerate(user_ids):
             # Set winner1, winner2, loser1, loser2 (leaving winner2 and loser2 empty if 2 players)
             match.__setattr__(


### PR DESCRIPTION
I have updated the APIs to use numbers where it makes more sense than to use number in strings.

- tournament creation now returns the whole tournament object
- `get_current_players()` function returns ids from the current logged in sessions
- array of numbers for `userIds`, number for `duration` and array of 2 numbers for `score` in JSON requests
- add `last` query param  to retrieve last tournaments and last matches. Now we can specify how many we want to get.
- add `finished` query param (true/false) to get only the finished matches