### PR TITLE
Upgrade Django version to 5.1.4

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 asgiref==3.8.1
 certifi==2024.8.30
 charset-normalizer==3.4.0
-Django==5.1.1
+Django==5.1.4
 django-cors-headers==4.5.0
 idna==3.10
 pillow==10.4.0


### PR DESCRIPTION
Updated version of Django to fix these vulnerabilities:
Django SQL injection in HasKey(lhs, rhs) on Oracle
Django denial-of-service in django.utils.html.strip_tags()

You may need to recreate your containers with `docker compose up --build` to get 5.1.4 version in the container.