### PR TITLE
Add gunicorn for production, Update nginx config for media directory

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,4 +34,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Run the Django development server by default
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+# CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+
+# Run Gunicorn (instead of Django's runserver) in production
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "backend.wsgi:application"]

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -24,8 +24,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-8qdt-&h8tvrci*#zuu72_+mqr&=u(5hl6qj=e%w8sayd_i*-2u'
 
 # SECURITY WARNING: don't run with debug turned on in production!
+# Debug mode should be set in .env file. DEBUG=0 to turn Debug mode off.
 DEBUG = os.environ.get('DEBUG', '1') == '1'  # Default to '1' if not set
-DEBUG = True
 
 ALLOWED_HOSTS = [
     'localhost',

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,6 +3,7 @@ certifi==2024.8.30
 charset-normalizer==3.4.0
 Django==5.1.1
 django-cors-headers==4.5.0
+gunicorn==23.0.0
 idna==3.10
 pillow==10.4.0
 psycopg==3.2.3

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -31,8 +31,13 @@ http {
 		ssl_certificate /etc/nginx/ssl/cert.crt;
 		ssl_certificate_key /etc/nginx/ssl/key.key;
 
+		location /media/ {
+			alias /media/;
+		}
+
 		root /var/www/html/;
 		index index.html;
+		
 		# try serving files in /var/www/html, if not found proxy request to django
 		# Serve static frontend first, fallback to Django backend
 		location / {


### PR DESCRIPTION
Fix for the avatars not served from the DEBUG=0.
Debug mode should be set from the `.env`

Avatars now work with the production mode for Django.
The problem was in the nginx.conf.
Now Dockerfile runs the gunicorn server for serving Django in production.