### PR TITLE
Fix find_ids_from_sessions checking all cookies

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -572,6 +572,8 @@ def get_tournament(request, id):
 def find_ids_from_sessions(request):
     found_session_ids = []
     for key, value in request.COOKIES.items():
+        if not key.startswith("session_"):
+            continue
         try:
             decrypted_value = decrypt_session_value(value)
             if decrypted_value and 'id' in decrypted_value:

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-8qdt-&h8tvrci*#zuu72_+mqr&=u(5hl6qj=e%w8sayd_i*-2u'
+SECRET_KEY = os.environ.get('AUTH_SALT')
 
 # SECURITY WARNING: don't run with debug turned on in production!
 # Debug mode should be set in .env file. DEBUG=0 to turn Debug mode off.


### PR DESCRIPTION
It was checking `csrftoken` and `sessionid` and basically all cookies. Limited the behaviour to check only cookies wit ha key starting with `session_`

No output like this anymore:
```
transc_backend  | Invalid decrypted value for cookie csrftoken
transc_backend  | Invalid decrypted value for cookie sessionid
```

Also, changed Django to use SECRET_KEY set in settings to use AUTH_SALT which we use for our custom encryption.