### PR TITLE
Add finished query param to /api/players/{id}/matches/ endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ Several users can be logged in at the same time. Each session is stored in cooki
 
 - **Endpoint**: `GET /api/players/{id}/matches/`
 
-- **Description**: Respond with array of all the player's `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). Can be limited to certain amount with `last` query parameter. At least one login session required.
+- **Description**: Respond with array of all the player's `matches` in array of objects with a match `id`, `score`, `duration`, `createdAt` and `players` array of objects (which have the same structure as `winner` in `tournament` object). Can be limited to certain amount with `last` query parameter. `finished` query parameter can be used to get finished and unfinished matches. At least one login session required.
 
 - **URL Parameters**:
 
@@ -773,6 +773,8 @@ Several users can be logged in at the same time. Each session is stored in cooki
 - **Query Parameters**:
 
   - `last` **(optional)**: Specifies the number of tournaments to return. Must be a positive integer. If not provided, defaults to 5. Example: `GET /api/players/{id}/matches/?last=10`.
+
+  - `finished` **(optional)**: Specifies to include only finished matches or not finished too. `?finished=false` mean that unfinished matches will be included. If not provided, defaults to true. Example: `GET /api/matches/?finished=false`. Default value: `true`.
 
 - **Example Response**:
 

--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -752,10 +752,7 @@ def get_matches(request):
     finished = request.GET.get("finished", "true")
     finished = finished.lower() == "true"
     last = int(request.GET.get("last") or 20)
-    if finished:
-        matches = Match.objects.exclude(score__isnull=True).order_by("-id")[:last]
-    else:
-        matches = Match.objects.all().order_by("-id")[:last]
+    matches = Match.objects.exclude(score__isnull=finished).order_by("-id")[:last]
     return [form_match_json(match) for match in matches]
 
 
@@ -764,13 +761,15 @@ def get_player_matches(request, id):
     try:
         if request.method == "GET":
             last = int(request.GET.get("last") or 5)
+            finished = request.GET.get("finished", "true")
+            finished = finished.lower() == "true"
             player = get_player_by_user_id(id)
             matches = Match.objects.filter(
                 Q(player1=player)
                 | Q(player2=player)
                 | Q(player3=player)
                 | Q(player4=player)
-            ).order_by("-id")[:last]
+            ).exclude(score__isnull=finished).order_by("-id")[:last]
             return JsonResponse(
                 {
                     "ok": True,


### PR DESCRIPTION
Defaults to true, so no need to edit anything on frontend.
All recent matches lists on frontend will show only finished matches.